### PR TITLE
Changed VirtualTimer to use std::function to allow for more complex l…

### DIFF
--- a/include/virtualTimer.h
+++ b/include/virtualTimer.h
@@ -1,11 +1,11 @@
 /**
  * @file virtualTimer.h
  * @author Chris Uustal
- * @brief Offers virtual timer functionality for task execution and checking if a certain duration of time has elapsed (in ms).
- * 			For general task execution purposes, make a new virtualTimerGroup_S object and addTimer(). For time elapsed, make
- * 			a new virtualTimer_S and start(), then getElapsedTime() or hasTimerExpired() for use in your code. You can combine
- * 			your own virtual timers and those created using addTimer() in a group by calling addTimer() with a pointer to your
- *			virtual timer.
+ * @brief Offers virtual timer functionality for task execution and checking if a certain duration of time has elapsed
+ *(in ms). For general task execution purposes, make a new virtualTimerGroup_S object and addTimer(). For time elapsed,
+ *make a new virtualTimer_S and start(), then getElapsedTime() or hasTimerExpired() for use in your code. You can
+ *combine your own virtual timers and those created using addTimer() in a group by calling addTimer() with a pointer to
+ *your virtual timer.
  * @version 1
  * @date 2022-09-11
  *
@@ -17,61 +17,63 @@
 #define VIRTUALTIMERS_H
 
 #include <stdint.h>
+
+#include <functional>
 #include <vector>
 
 class VirtualTimer
 {
 public:
-	/********** ENUMS **********/
-	enum class State
-	{
-		kNotStarted,
-		kRunning,
-		kExpired,
-	};
+    /********** ENUMS **********/
+    enum class State
+    {
+        kNotStarted,
+        kRunning,
+        kExpired,
+    };
 
-	enum class Type
-	{
-		kSingleUse,
-		kRepeating,
-		kUninitialized,
-	};
+    enum class Type
+    {
+        kSingleUse,
+        kRepeating,
+        kUninitialized,
+    };
 
-	/********** PROTOTYPES **********/
-	VirtualTimer();
-	VirtualTimer(uint32_t duration_ms, void (*task_func)(void), Type timer_type);
-	void Init(uint32_t duration_ms, void (*task_func)(void), Type timer_type);
-	void Start(uint32_t current_time);
-	State GetTimerState();
-	bool HasTimerExpired();
-	uint32_t GetElapsedTime(uint32_t current_time);
-	bool Tick(uint32_t current_time);
+    /********** PROTOTYPES **********/
+    VirtualTimer();
+    VirtualTimer(uint32_t duration_ms, std::function<void(void)> task_func, Type timer_type);
+    void Init(uint32_t duration_ms, std::function<void(void)> task_func, Type timer_type);
+    void Start(uint32_t current_time);
+    State GetTimerState();
+    bool HasTimerExpired();
+    uint32_t GetElapsedTime(uint32_t current_time);
+    bool Tick(uint32_t current_time);
 
-	/********** VARIABLES **********/
-	uint32_t duration;
+    /********** VARIABLES **********/
+    uint32_t duration;
 
 private:
-	uint32_t prev_tick = 0U;
+    uint32_t prev_tick = 0U;
 
-	void (*task_func)(void) = nullptr;
+    std::function<void(void)> task_func;
 
-	State state = State::kNotStarted;
-	Type type;
+    State state = State::kNotStarted;
+    Type type;
 };
 
 class VirtualTimerGroup
 {
 public:
-	/********** PROTOTYPES **********/
-	VirtualTimerGroup();
-	void AddTimer(VirtualTimer *new_timer);
-	void AddTimer(uint32_t duration_ms, void (*task_func)(void));
-	bool Tick(uint32_t current_time);
+    /********** PROTOTYPES **********/
+    VirtualTimerGroup();
+    void AddTimer(VirtualTimer *new_timer);
+    void AddTimer(uint32_t duration_ms, std::function<void(void)> task_func);
+    bool Tick(uint32_t current_time);
 
 private:
-	uint32_t prev_tick = 0U;
-	uint32_t min_timer_duration;
-	std::vector<VirtualTimer> timer_group;
+    uint32_t prev_tick = 0U;
+    uint32_t min_timer_duration;
+    std::vector<VirtualTimer> timer_group;
 };
 
 #endif

--- a/include/virtualTimer.h
+++ b/include/virtualTimer.h
@@ -66,7 +66,7 @@ class VirtualTimerGroup
 public:
     /********** PROTOTYPES **********/
     VirtualTimerGroup();
-    void AddTimer(VirtualTimer *new_timer);
+    void AddTimer(VirtualTimer &new_timer);
     void AddTimer(uint32_t duration_ms, std::function<void(void)> task_func);
     bool Tick(uint32_t current_time);
 

--- a/include/virtualTimer.h
+++ b/include/virtualTimer.h
@@ -73,7 +73,7 @@ public:
 private:
     uint32_t prev_tick = 0U;
     uint32_t min_timer_duration;
-    std::vector<VirtualTimer> timer_group;
+    std::vector<VirtualTimer *> timer_group;
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include <Arduino.h>
+
 #include "virtualTimer.h"
 
 void run10ms()
@@ -10,7 +11,7 @@ void run100ms()
 void run250ms() { Serial.println("250ms"); }
 void run1000ms()
 { /* DO SOMETHING AT 1000ms */
-	Serial.println("1000ms");
+    Serial.println("1000ms");
 }
 
 VirtualTimer t1000(1000U, run1000ms, VirtualTimer::Type::kRepeating);
@@ -18,20 +19,20 @@ VirtualTimerGroup timer_group;
 
 void setup()
 {
-	Serial.begin(115200);
+    Serial.begin(115200);
 
-	// Make your own timers and add them to the group
-	timer_group.AddTimer(&t1000);
-	// Or just add them directly as part of the group
-	timer_group.AddTimer(10U, run10ms);
-	timer_group.AddTimer(250U, run250ms);
+    // Make your own timers and add them to the group
+    timer_group.AddTimer(t1000);
+    // Or just add them directly as part of the group
+    timer_group.AddTimer(10U, run10ms);
+    timer_group.AddTimer(250U, run250ms);
 }
 
 void loop()
 {
-	if (timer_group.Tick(millis()) == false)
-	{
-		// The time between one tick and the next exceeded the timer for the shortest task
-		Serial.println("Timing Violation");
-	}
+    if (timer_group.Tick(millis()) == false)
+    {
+        // The time between one tick and the next exceeded the timer for the shortest task
+        Serial.println("Timing Violation");
+    }
 }

--- a/src/virtualTimer.cpp
+++ b/src/virtualTimer.cpp
@@ -174,7 +174,7 @@ void VirtualTimerGroup::AddTimer(VirtualTimer &new_timer)
         min_timer_duration = new_timer.duration;
     }
 
-    timer_group.push_back(new_timer);
+    timer_group.push_back(&new_timer);
 }
 
 /**
@@ -192,7 +192,7 @@ void VirtualTimerGroup::AddTimer(uint32_t duration_ms, std::function<void(void)>
         min_timer_duration = duration_ms;
     }
 
-    timer_group.emplace_back(VirtualTimer(duration_ms, task_func, VirtualTimer::Type::kRepeating));
+    timer_group.emplace_back(new VirtualTimer(duration_ms, task_func, VirtualTimer::Type::kRepeating));
 }
 
 /**
@@ -214,15 +214,15 @@ bool VirtualTimerGroup::Tick(uint32_t current_time)
             ret = false;
         }
 
-        std::vector<VirtualTimer>::iterator i;
+        std::vector<VirtualTimer *>::iterator i;
         for (i = timer_group.begin(); i != timer_group.end(); i++)
         {
-            if (i->GetTimerState() != VirtualTimer::State::kRunning)
+            if ((*i)->GetTimerState() != VirtualTimer::State::kRunning)
             {
-                i->Start(current_time);
+                (*i)->Start(current_time);
             }
 
-            if (i->Tick(current_time) == false)
+            if ((*i)->Tick(current_time) == false)
             {
                 ret = false;
             }

--- a/src/virtualTimer.cpp
+++ b/src/virtualTimer.cpp
@@ -29,7 +29,7 @@ VirtualTimer::VirtualTimer()
  * @param task_func - Function to be called when timer expires
  * @param timer_type - If the timer should be repeating or single-use
  */
-VirtualTimer::VirtualTimer(uint32_t duration_ms, void (*task_func)(void), Type timer_type)
+VirtualTimer::VirtualTimer(uint32_t duration_ms, std::function<void(void)> task_func, Type timer_type)
 {
     if (duration_ms != 0U)
     {
@@ -46,7 +46,7 @@ VirtualTimer::VirtualTimer(uint32_t duration_ms, void (*task_func)(void), Type t
  * @param task_func - Function to be called when timer expires
  * @param timer_type - If the timer should be repeating or single-use
  */
-void VirtualTimer::Init(uint32_t duration_ms, void (*task_func)(void), Type timer_type)
+void VirtualTimer::Init(uint32_t duration_ms, std::function<void(void)> task_func, Type timer_type)
 {
     if (duration_ms != 0U)
     {
@@ -73,10 +73,7 @@ void VirtualTimer::Start(uint32_t current_time)
  * @param current_time - the current time in ms at the time of calling (eg. millis())
  * @return Current state of the timer
  */
-VirtualTimer::State VirtualTimer::GetTimerState()
-{
-    return state;
-}
+VirtualTimer::State VirtualTimer::GetTimerState() { return state; }
 
 /**
  * @brief Check if the timer has expired but do not update it
@@ -159,9 +156,7 @@ bool VirtualTimer::Tick(uint32_t current_time)
  * @brief Default constructor for VirtualTimerGroup
  *
  */
-VirtualTimerGroup::VirtualTimerGroup()
-{
-}
+VirtualTimerGroup::VirtualTimerGroup() {}
 
 /**
  * @brief Add an existing timer to the timer group
@@ -190,7 +185,7 @@ void VirtualTimerGroup::AddTimer(VirtualTimer *new_timer)
  * @return true = timer was added successfully
  * @return false = failed to add timer (likely reached the max number of timers)
  */
-void VirtualTimerGroup::AddTimer(uint32_t duration_ms, void (*task_func)(void))
+void VirtualTimerGroup::AddTimer(uint32_t duration_ms, std::function<void(void)> task_func)
 {
     VirtualTimer *new_timer = new VirtualTimer;
 

--- a/src/virtualTimer.cpp
+++ b/src/virtualTimer.cpp
@@ -192,7 +192,7 @@ void VirtualTimerGroup::AddTimer(uint32_t duration_ms, std::function<void(void)>
         min_timer_duration = duration_ms;
     }
 
-    timer_group.push_back(VirtualTimer(duration_ms, task_func, VirtualTimer::Type::kRepeating));
+    timer_group.emplace_back(VirtualTimer(duration_ms, task_func, VirtualTimer::Type::kRepeating));
 }
 
 /**

--- a/src/virtualTimer.cpp
+++ b/src/virtualTimer.cpp
@@ -167,14 +167,14 @@ void VirtualTimerGroup::AddTimer(VirtualTimer &new_timer)
 {
     if (timer_group.empty())
     {
-        min_timer_duration = new_timer->duration;
+        min_timer_duration = new_timer.duration;
     }
-    else if (new_timer->duration < min_timer_duration)
+    else if (new_timer.duration < min_timer_duration)
     {
-        min_timer_duration = new_timer->duration;
+        min_timer_duration = new_timer.duration;
     }
 
-    timer_group.push_back(*new_timer);
+    timer_group.push_back(new_timer);
 }
 
 /**
@@ -187,20 +187,12 @@ void VirtualTimerGroup::AddTimer(VirtualTimer &new_timer)
  */
 void VirtualTimerGroup::AddTimer(uint32_t duration_ms, std::function<void(void)> task_func)
 {
-    VirtualTimer *new_timer = new VirtualTimer;
-
-    new_timer->Init(duration_ms, task_func, VirtualTimer::Type::kRepeating);
-
-    if (timer_group.empty())
+    if (timer_group.empty() || duration_ms < min_timer_duration)
     {
-        min_timer_duration = new_timer->duration;
-    }
-    else if (new_timer->duration < min_timer_duration)
-    {
-        min_timer_duration = new_timer->duration;
+        min_timer_duration = duration_ms;
     }
 
-    timer_group.push_back(*new_timer);
+    timer_group.push_back(VirtualTimer(duration_ms, task_func, VirtualTimer::Type::kRepeating));
 }
 
 /**

--- a/src/virtualTimer.cpp
+++ b/src/virtualTimer.cpp
@@ -163,7 +163,7 @@ VirtualTimerGroup::VirtualTimerGroup() {}
  *
  * @param newTimer = existig timer to be added to the group
  */
-void VirtualTimerGroup::AddTimer(VirtualTimer *new_timer)
+void VirtualTimerGroup::AddTimer(VirtualTimer &new_timer)
 {
     if (timer_group.empty())
     {


### PR DESCRIPTION
…amba functions to be passed. This is required for passing member functions, which the CANTXMessage requires.

Also changed some functions to pass by reference instead of passing a pointer, refactored AddTimer(duration, function), and changed the timer_group vector to store pointers instead of copies of timers.
***This should be tested before merging